### PR TITLE
Skip cache for more cart and sitemap plugins

### DIFF
--- a/ee/cli/templates/redis-hhvm.mustache
+++ b/ee/cli/templates/redis-hhvm.mustache
@@ -9,11 +9,11 @@ if ($query_string != "") {
   set $skip_cache 1;
 }
 # Don't cache URL containing the following segments
-if ($request_uri ~* "(/wp-admin/|/xmlrpc.php|wp-.*.php|index.php|/feed/|sitemap(_index)?.xml|[a-z0-9_-]+-sitemap([0-9]+)?.xml)") {
+if ($request_uri ~* "(/wp-admin/|/xmlrpc.php|wp-.*\.php|index.php|/feed/|.*sitemap.*\.xml)") {
   set $skip_cache 1;
 }
 # Don't use the cache for logged in users or recent commenter or customer with items in cart
-if ($http_cookie ~* "comment_author|wordpress_[a-f0-9]+|wp-postpass|wordpress_no_cache|wordpress_logged_in|woocommerce_items_in_cart") {
+if ($http_cookie ~* "comment_author|wordpress_[a-f0-9]+|wp-postpass|wordpress_no_cache|wordpress_logged_in|[a-z0-9]+_items_in_cart") {
   set $skip_cache 1;
 }
 # Use cached or actual file if they exists, Otherwise pass request to WordPress

--- a/ee/cli/templates/redis-php7.mustache
+++ b/ee/cli/templates/redis-php7.mustache
@@ -9,11 +9,11 @@ if ($query_string != "") {
   set $skip_cache 1;
 }
 # Don't cache URL containing the following segments
-if ($request_uri ~* "(/wp-admin/|/xmlrpc.php|wp-.*.php|index.php|/feed/|sitemap(_index)?.xml|[a-z0-9_-]+-sitemap([0-9]+)?.xml)") {
+if ($request_uri ~* "(/wp-admin/|/xmlrpc.php|wp-.*\.php|index.php|/feed/|.*sitemap.*\.xml)") {
   set $skip_cache 1;
 }
 # Don't use the cache for logged in users or recent commenter or customer with items in cart
-if ($http_cookie ~* "comment_author|wordpress_[a-f0-9]+|wp-postpass|wordpress_no_cache|wordpress_logged_in|woocommerce_items_in_cart") {
+if ($http_cookie ~* "comment_author|wordpress_[a-f0-9]+|wp-postpass|wordpress_no_cache|wordpress_logged_in|[a-z0-9]+_items_in_cart") {
   set $skip_cache 1;
 }
 # Use cached or actual file if they exists, Otherwise pass request to WordPress

--- a/ee/cli/templates/redis.mustache
+++ b/ee/cli/templates/redis.mustache
@@ -9,11 +9,11 @@ if ($query_string != "") {
   set $skip_cache 1;
 }
 # Don't cache URL containing the following segments
-if ($request_uri ~* "(/wp-admin/|/xmlrpc.php|wp-.*.php|index.php|/feed/|sitemap(_index)?.xml|[a-z0-9_-]+-sitemap([0-9]+)?.xml)") {
+if ($request_uri ~* "(/wp-admin/|/xmlrpc.php|wp-.*\.php|index.php|/feed/|.*sitemap.*\.xml)") {
   set $skip_cache 1;
 }
 # Don't use the cache for logged in users or recent commenter or customer with items in cart
-if ($http_cookie ~* "comment_author|wordpress_[a-f0-9]+|wp-postpass|wordpress_no_cache|wordpress_logged_in|woocommerce_items_in_cart") {
+if ($http_cookie ~* "comment_author|wordpress_[a-f0-9]+|wp-postpass|wordpress_no_cache|wordpress_logged_in|[a-z0-9]+_items_in_cart") {
   set $skip_cache 1;
 }
 # Use cached or actual file if they exists, Otherwise pass request to WordPress

--- a/ee/cli/templates/w3tc-hhvm.mustache
+++ b/ee/cli/templates/w3tc-hhvm.mustache
@@ -10,11 +10,11 @@ if ($query_string != "") {
   set $cache_uri 'null cache';
 }
 # Don't cache URL containing the following segments
-if ($request_uri ~* "(/wp-admin/|/xmlrpc.php|wp-.*.php|index.php|/feed/|sitemap(_index)?.xml|[a-z0-9_-]+-sitemap([0-9]+)?.xml)") {
+if ($request_uri ~* "(/wp-admin/|/xmlrpc.php|wp-.*\.php|index.php|/feed/|.*sitemap.*\.xml)") {
   set $cache_uri 'null cache';
 }
 # Don't use the cache for logged in users or recent commenter or customer with items in cart
-if ($http_cookie ~* "comment_author|wordpress_[a-f0-9]+|wp-postpass|wordpress_logged_in|woocommerce_items_in_cart") {
+if ($http_cookie ~* "comment_author|wordpress_[a-f0-9]+|wp-postpass|wordpress_no_cache|wordpress_logged_in|[a-z0-9]+_items_in_cart") {
   set $cache_uri 'null cache';
 }
 # Use cached or actual file if they exists, Otherwise pass request to WordPress

--- a/ee/cli/templates/w3tc-php7.mustache
+++ b/ee/cli/templates/w3tc-php7.mustache
@@ -10,11 +10,11 @@ if ($query_string != "") {
   set $cache_uri 'null cache';
 }
 # Don't cache URL containing the following segments
-if ($request_uri ~* "(/wp-admin/|/xmlrpc.php|wp-.*.php|index.php|/feed/|sitemap(_index)?.xml|[a-z0-9_-]+-sitemap([0-9]+)?.xml)") {
+if ($request_uri ~* "(/wp-admin/|/xmlrpc.php|wp-.*\.php|index.php|/feed/|.*sitemap.*\.xml)") {
   set $cache_uri 'null cache';
 }
 # Don't use the cache for logged in users or recent commenter or customer with items in cart
-if ($http_cookie ~* "comment_author|wordpress_[a-f0-9]+|wp-postpass|wordpress_logged_in|woocommerce_items_in_cart") {
+if ($http_cookie ~* "comment_author|wordpress_[a-f0-9]+|wp-postpass|wordpress_no_cache|wordpress_logged_in|[a-z0-9]+_items_in_cart") {
   set $cache_uri 'null cache';
 }
 # Use cached or actual file if they exists, Otherwise pass request to WordPress

--- a/ee/cli/templates/w3tc.mustache
+++ b/ee/cli/templates/w3tc.mustache
@@ -10,11 +10,11 @@ if ($query_string != "") {
   set $cache_uri 'null cache';
 }
 # Don't cache URL containing the following segments
-if ($request_uri ~* "(/wp-admin/|/xmlrpc.php|wp-.*.php|index.php|/feed/|sitemap(_index)?.xml|[a-z0-9_-]+-sitemap([0-9]+)?.xml)") {
+if ($request_uri ~* "(/wp-admin/|/xmlrpc.php|wp-.*\.php|index.php|/feed/|.*sitemap.*\.xml)") {
   set $cache_uri 'null cache';
 }
 # Don't use the cache for logged in users or recent commenter or customer with items in cart
-if ($http_cookie ~* "comment_author|wordpress_[a-f0-9]+|wp-postpass|wordpress_logged_in|woocommerce_items_in_cart") {
+if ($http_cookie ~* "comment_author|wordpress_[a-f0-9]+|wp-postpass|wordpress_no_cache|wordpress_logged_in|[a-z0-9]+_items_in_cart") {
   set $cache_uri 'null cache';
 }
 # Use cached or actual file if they exists, Otherwise pass request to WordPress

--- a/ee/cli/templates/wpfc-hhvm.mustache
+++ b/ee/cli/templates/wpfc-hhvm.mustache
@@ -9,11 +9,11 @@ if ($query_string != "") {
   set $skip_cache 1;
 }
 # Don't cache URL containing the following segments
-if ($request_uri ~* "(/wp-admin/|/xmlrpc.php|wp-.*.php|index.php|/feed/|sitemap(_index)?.xml|[a-z0-9_-]+-sitemap([0-9]+)?.xml)") {
+if ($request_uri ~* "(/wp-admin/|/xmlrpc.php|wp-.*\.php|index.php|/feed/|.*sitemap.*\.xml)") {
   set $skip_cache 1;
 }
 # Don't use the cache for logged in users or recent commenter or customer with items in cart
-if ($http_cookie ~* "comment_author|wordpress_[a-f0-9]+|wp-postpass|wordpress_no_cache|wordpress_logged_in|woocommerce_items_in_cart") {
+if ($http_cookie ~* "comment_author|wordpress_[a-f0-9]+|wp-postpass|wordpress_no_cache|wordpress_logged_in|[a-z0-9]+_items_in_cart") {
   set $skip_cache 1;
 }
 # Use cached or actual file if they exists, Otherwise pass request to WordPress

--- a/ee/cli/templates/wpfc-php7.mustache
+++ b/ee/cli/templates/wpfc-php7.mustache
@@ -9,11 +9,11 @@ if ($query_string != "") {
   set $skip_cache 1;
 }
 # Don't cache URL containing the following segments
-if ($request_uri ~* "(/wp-admin/|/xmlrpc.php|wp-.*.php|index.php|/feed/|sitemap(_index)?.xml|[a-z0-9_-]+-sitemap([0-9]+)?.xml)") {
+if ($request_uri ~* "(/wp-admin/|/xmlrpc.php|wp-.*\.php|index.php|/feed/|.*sitemap.*\.xml)") {
   set $skip_cache 1;
 }
 # Don't use the cache for logged in users or recent commenter or customer with items in cart
-if ($http_cookie ~* "comment_author|wordpress_[a-f0-9]+|wp-postpass|wordpress_no_cache|wordpress_logged_in|woocommerce_items_in_cart") {
+if ($http_cookie ~* "comment_author|wordpress_[a-f0-9]+|wp-postpass|wordpress_no_cache|wordpress_logged_in|[a-z0-9]+_items_in_cart") {
   set $skip_cache 1;
 }
 # Use cached or actual file if they exists, Otherwise pass request to WordPress

--- a/ee/cli/templates/wpfc.mustache
+++ b/ee/cli/templates/wpfc.mustache
@@ -9,11 +9,11 @@ if ($query_string != "") {
   set $skip_cache 1;
 }
 # Don't cache URL containing the following segments
-if ($request_uri ~* "(/wp-admin/|/xmlrpc.php|wp-.*.php|index.php|/feed/|sitemap(_index)?.xml|[a-z0-9_-]+-sitemap([0-9]+)?.xml)") {
+if ($request_uri ~* "(/wp-admin/|/xmlrpc.php|wp-.*\.php|index.php|/feed/|.*sitemap.*\.xml)") {
   set $skip_cache 1;
 }
 # Don't use the cache for logged in users or recent commenter or customer with items in cart
-if ($http_cookie ~* "comment_author|wordpress_[a-f0-9]+|wp-postpass|wordpress_no_cache|wordpress_logged_in|woocommerce_items_in_cart") {
+if ($http_cookie ~* "comment_author|wordpress_[a-f0-9]+|wp-postpass|wordpress_no_cache|wordpress_logged_in|[a-z0-9]+_items_in_cart") {
   set $skip_cache 1;
 }
 # Use cached or actual file if they exists, Otherwise pass request to WordPress

--- a/ee/cli/templates/wpsc-hhvm.mustache
+++ b/ee/cli/templates/wpsc-hhvm.mustache
@@ -9,11 +9,11 @@ if ($query_string != "") {
   set $cache_uri 'null cache';
 }
 # Don't cache URL containing the following segments
-if ($request_uri ~* "(/wp-admin/|/xmlrpc.php|wp-.*.php|index.php|/feed/|sitemap(_index)?.xml|[a-z0-9_-]+-sitemap([0-9]+)?.xml)") {
+if ($request_uri ~* "(/wp-admin/|/xmlrpc.php|wp-.*\.php|index.php|/feed/|.*sitemap.*\.xml)") {
   set $cache_uri 'null cache';
 }
 # Don't use the cache for logged in users or recent commenter or customer with items in cart
-if ($http_cookie ~* "comment_author|wordpress_[a-f0-9]+|wp-postpass|wordpress_logged_in|woocommerce_items_in_cart") {
+if ($http_cookie ~* "comment_author|wordpress_[a-f0-9]+|wp-postpass|wordpress_no_cache|wordpress_logged_in|[a-z0-9]+_items_in_cart") {
   set $cache_uri 'null cache';
 }
 # Use cached or actual file if they exists, Otherwise pass request to WordPress

--- a/ee/cli/templates/wpsc-php7.mustache
+++ b/ee/cli/templates/wpsc-php7.mustache
@@ -9,11 +9,11 @@ if ($query_string != "") {
   set $cache_uri 'null cache';
 }
 # Don't cache URL containing the following segments
-if ($request_uri ~* "(/wp-admin/|/xmlrpc.php|wp-.*.php|index.php|/feed/|sitemap(_index)?.xml|[a-z0-9_-]+-sitemap([0-9]+)?.xml)") {
+if ($request_uri ~* "(/wp-admin/|/xmlrpc.php|wp-.*\.php|index.php|/feed/|.*sitemap.*\.xml)") {
   set $cache_uri 'null cache';
 }
 # Don't use the cache for logged in users or recent commenter or customer with items in cart
-if ($http_cookie ~* "comment_author|wordpress_[a-f0-9]+|wp-postpass|wordpress_logged_in|woocommerce_items_in_cart") {
+if ($http_cookie ~* "comment_author|wordpress_[a-f0-9]+|wp-postpass|wordpress_no_cache|wordpress_logged_in|[a-z0-9]+_items_in_cart") {
   set $cache_uri 'null cache';
 }
 # Use cached or actual file if they exists, Otherwise pass request to WordPress

--- a/ee/cli/templates/wpsc.mustache
+++ b/ee/cli/templates/wpsc.mustache
@@ -9,11 +9,11 @@ if ($query_string != "") {
   set $cache_uri 'null cache';
 }
 # Don't cache URL containing the following segments
-if ($request_uri ~* "(/wp-admin/|/xmlrpc.php|wp-.*.php|index.php|/feed/|sitemap(_index)?.xml|[a-z0-9_-]+-sitemap([0-9]+)?.xml)") {
+if ($request_uri ~* "(/wp-admin/|/xmlrpc.php|wp-.*\.php|index.php|/feed/|.*sitemap.*\.xml)") {
   set $cache_uri 'null cache';
 }
 # Don't use the cache for logged in users or recent commenter or customer with items in cart
-if ($http_cookie ~* "comment_author|wordpress_[a-f0-9]+|wp-postpass|wordpress_logged_in|woocommerce_items_in_cart") {
+if ($http_cookie ~* "comment_author|wordpress_[a-f0-9]+|wp-postpass|wordpress_no_cache|wordpress_logged_in|[a-z0-9]+_items_in_cart") {
   set $cache_uri 'null cache';
 }
 # Use cached or actual file if they exists, Otherwise pass request to WordPress


### PR DESCRIPTION
Changed skip_cache flag triggers to be more inclusive with respect to multiple alternative WordPress shopping cart and xml sitemap plugins, not just Woo and Yoast... Now also Easy Digital Downloads, XML Sitemap + Google News Feeds, Better XML Sitemaps and XML Sitemap Generator.